### PR TITLE
Make Searchable BelongsTo field with Quick Create scale correctly

### DIFF
--- a/resources/js/components/belongs-to/FormField.vue
+++ b/resources/js/components/belongs-to/FormField.vue
@@ -20,7 +20,7 @@
             :data='availableResources'
             trackBy='value'
             searchBy='display'
-            class="mb-3"
+            class="mb-3 flex-grow"
           >
             <div
               slot="default"


### PR DESCRIPTION
When using the BelongsTo field with the `quickCreate` option while also using the `searchable` variant, it does not scale nicely. This simple fix will adjust that.