### PR TITLE
Autocomplete field

### DIFF
--- a/resources/js/components/autocomplete/FormField.vue
+++ b/resources/js/components/autocomplete/FormField.vue
@@ -58,6 +58,10 @@ export default {
     },
 
     selectedValue() {
+      if (this.field.computeOptions && typeof this.field.computeOptions !== 'undefined') {
+        this.fetchComputedValues()
+      }
+
       if (!this.options) {
         return null
       }
@@ -90,7 +94,6 @@ export default {
 
     computedOptionsReceived(data) {
       if (data && JSON.stringify(data) !== JSON.stringify(this.options)) {
-        this.value = null
         this.options = data
       }
     },


### PR DESCRIPTION
Autocomplete field now fetch computed values when is created. There is a side effect on line 93, `this.value = null`

Leaving it causes the initial values to not be loaded, removing it caused values not being reset after a field change 