### PR TITLE
initial step towards enabling proper JSON field nesting

### DIFF
--- a/src/JSON.php
+++ b/src/JSON.php
@@ -119,7 +119,7 @@ class JSON extends Field
     {
         $attribute = $attribute ?? $this->attribute;
 
-        $value = $resource->{$attribute};
+        $value = data_get($resource, $attribute);
 
         $this->value = is_object($value) || is_array($value) ? $value : json_decode($value);
 
@@ -182,7 +182,7 @@ class JSON extends Field
     {
         $attribute = $attribute ?? $this->attribute;
 
-        $value = $resource->{$attribute};
+        $value = data_get($resource, $attribute);
 
         $this->value = is_object($value) || is_array($value) ? $value : json_decode($value);
 


### PR DESCRIPTION
This is related to #14, it doesn't fix it but works towards enabling it by making the resolving portion work as expected. This is to enable the nesting to work off of non models, like a json object/array would be.
Slightly more specific case this fixes, is if you currently use a JSON field inside another JSON field, if have a structure that goes 3 levels deep and have the corresponding 3 JSON field levels, the inner JSON fields can fail based on the fact that one of those levels might not be something that is object.

JSON:`{"extra_attributes": { "hours": { "monday": { "open": "08:00", "close": "17:00"}}}}`

Field layout:

    JSON::make('Extra Attributes', [
        JSON::make('Hours', [
            JSON::make('Monday', [
                Text::make('Open'), 
                Text::make('Close')
            ]),
        ]),
    ])

This structure is impossible without this update to ensure that the JSON field can access deep non-object/model properties.