### PR TITLE
Fix: Uncompilable declaration of jsonSerialize function.

### DIFF
--- a/src/JSON.php
+++ b/src/JSON.php
@@ -196,7 +196,7 @@ class JSON extends Field
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_merge(parent::jsonSerialize(), [
             'panelTitleClasses' => $this->panelTitleClasses,


### PR DESCRIPTION
Fix the Uncompilable declaration of jsonSerialize function while using strict types.

The error says: Declaration of R64\\NovaFields\\JSON::jsonSerialize() must be compatible with Laravel\\Nova\\Fields\\Field::jsonSerialize(): array